### PR TITLE
Revert "Refreshed to v1.8.0"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set name = "onnx" %}
-{% set version = "1.8.0" %}
+{% set version = "1.6.0" %}
+# git tag can be any value that works with git checkout
+{% set git_tag = "fea8568cac61a482ed208748fdc0e1a8e4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +9,7 @@ package:
 
 source:
   git_url: "https://github.com/onnx/onnx.git"
-  git_tag: v{{ version }}
+  git_tag: {{ git_tag }}
 
 build:
   number: 2
@@ -36,7 +38,6 @@ requirements:
     - libprotobuf {{ protobuf }}
     - numpy {{ numpy }}
     - six {{ six }}
-    - typing-extensions {{ typing_extensions }}
 
 test:
   imports:


### PR DESCRIPTION
Reverts open-ce/onnx-feedstock#7

This relied on having the typing_extensions variable defined, which hasn't been merged in yet.