### PR TITLE
[1.2] Fix onnx 1.6.0 for pb 3.11.x

### DIFF
--- a/recipe/0101-python_out-does-not-recognize-dllexport_decl.patch
+++ b/recipe/0101-python_out-does-not-recognize-dllexport_decl.patch
@@ -1,0 +1,25 @@
+From e75eb97942d2bef47712890b5162734cff173132 Mon Sep 17 00:00:00 2001
+From: Jason Furmanek <furmanek@us.ibm.com>
+Date: Wed, 18 Nov 2020 20:47:31 +0000
+Subject: [PATCH] python_out does not recognize dllexport_decl.
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8351a520..613ea769 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -226,7 +226,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
+         ${ONNX_DLLEXPORT_STR}${CMAKE_CURRENT_BINARY_DIR})
+     if(BUILD_ONNX_PYTHON)
+       list(APPEND PROTOC_ARGS --python_out
+-                  ${ONNX_DLLEXPORT_STR}${CMAKE_CURRENT_BINARY_DIR})
++                  ${CMAKE_CURRENT_BINARY_DIR})
+       if(ONNX_GEN_PB_TYPE_STUBS)
+         # Haven't figured out how to generate mypy stubs on Windows yet
+         if(NOT WIN32)
+-- 
+2.27.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ package:
 source:
   git_url: "https://github.com/onnx/onnx.git"
   git_tag: {{ git_tag }}
+  patches:
+    - 0101-python_out-does-not-recognize-dllexport_decl.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0101-python_out-does-not-recognize-dllexport_decl.patch
 
 build:
-  number: 2
+  number: 3
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   entry_points:
     - check-model = onnx.bin.checker:check_model

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
   git_url: "https://github.com/onnx/onnx.git"
   git_tag: {{ git_tag }}
   patches:
+{% if protobuf=="3.11.2" %}  # open-ce 1.2
     - 0101-python_out-does-not-recognize-dllexport_decl.patch
+{% endif %}
 
 build:
   number: 6


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

This fixes ONNX 1.6.0 builds when using protobuf 3.11 or newer.
TensorFlow 2.4 and PyTorch 1.7 are moving to a new protobuf, but we want to stay with ONNX 1.6 for now since TensorRT is still there.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
