### PR TITLE
Be explicit with cmake [Ubuntu fix]

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,4 +17,13 @@
 export ONNX_ML=1
 export CONDA_PREFIX="$PREFIX"  # build script looks at this, but not set on
 
+# Let's be explicit with CMake.
+export CMAKE_ARGS="${CMAKE_ARGS} -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc -DProtobuf_LIBRARY=$PREFIX/lib/libprotobuf${SHLIB_EXT}"
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_AR=${AR}"
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_LINKER=${LD}"
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_NM=${NM}"
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_OBJCOPY=${OBJCOPY}"
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_OBJDUMP=${OBJDUMP}"
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_RANLIB=${RANLIB}"
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_STRIP=${STRIP}"
 python -m pip install --no-deps --ignore-installed --verbose .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake {{ cmake }}
     - make                # needed by cmake
+    - libprotobuf {{ protobuf }}
   host:
     - python {{ python }}
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 {% endif %}
 
 build:
-  number: 6
+  number: 7
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   entry_points:
     - check-model = onnx.bin.checker:check_model


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Cmake is unpredictable at times and is prone to build environment leakage. In this case, the ONNX recipe won't build on Ubuntu OS's without local compilers installed. If we are extra explicit about all of the binutils locations in conda, then Cmake is happy.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
